### PR TITLE
Added logging to Version.h, added log timestamp and added var args to log function

### DIFF
--- a/openGLdemo/Source.cpp
+++ b/openGLdemo/Source.cpp
@@ -1,5 +1,7 @@
 // ctime is deemed not secure by MSVC so we disable warnings
-#define _CRT_SECURE_NO_WARNINGS
+#if _MSC_VER && !__INTEL_COMPILER
+	#define _CRT_SECURE_NO_WARNINGS
+#endif
 #include "Callbacks.h"
 #include "Input.h"
 #include "Utilities.h"

--- a/openGLdemo/Source.cpp
+++ b/openGLdemo/Source.cpp
@@ -1,3 +1,5 @@
+// ctime is deemed not secure by MSVC so we disable warnings
+#define _CRT_SECURE_NO_WARNINGS
 #include "Callbacks.h"
 #include "Input.h"
 #include "Utilities.h"

--- a/openGLdemo/Utilities.h
+++ b/openGLdemo/Utilities.h
@@ -14,16 +14,33 @@ const char* extract_prog_name(const char* full)
 	return p2.c_str();
 }
 
+const char* getCurrentTime()
+{
+	auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+
+        std::string realTime = std::ctime(&now);
+
+	// The 25th character has a '\n' which we do not want so we do this
+        realTime[24] = NULL;
+
+	return realTime.c_str();
+}
+
 #ifdef _DEBUG
-void write_log(const char* msg)
+template<typename... args>
+void write_log(const char* msg, args&&... argv)
 {
 	std::ofstream logs;
 	logs.open("our_log.txt", std::ofstream::app | std::ofstream::out);
-	logs << msg << '\n';
+	
+	logs << "[" << getCurrentTime() << "] " << msg;
+	(logs << ... << argv);
+	logs << '\n';
 	logs.close();
 }
 #else
-void write_log(const char* msg)
+template<typename... args>
+void write_log(const char* msg, args&&... argv)
 {
 }
 #endif

--- a/openGLdemo/Utilities.h
+++ b/openGLdemo/Utilities.h
@@ -14,7 +14,7 @@ const char* extract_prog_name(const char* full)
 	return p2.c_str();
 }
 
-const char* getCurrentTime()
+const char* get_current_time()
 {
 	auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
@@ -33,7 +33,7 @@ void write_log(const char* msg, args&&... argv)
 	std::ofstream logs;
 	logs.open("our_log.txt", std::ofstream::app | std::ofstream::out);
 	
-	logs << "[" << getCurrentTime() << "] " << msg;
+	logs << "[" << get_current_time() << "] " << msg;
 	(logs << ... << argv);
 	logs << '\n';
 	logs.close();

--- a/openGLdemo/Utilities.h
+++ b/openGLdemo/Utilities.h
@@ -16,16 +16,13 @@ const char* extract_prog_name(const char* full)
 	return p2.c_str();
 }
 
-const char* get_current_time()
+std::string get_current_time()
 {
 	auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-
         std::string realTime = std::ctime(&now);
-
-	// The 25th character has a '\n' which we do not want so we do this
+	// The 25th character has a '\n' which we do not want
         realTime[24] = NULL;
-
-	return realTime.c_str();
+	return realTime;
 }
 
 #ifdef _DEBUG
@@ -34,7 +31,6 @@ void write_log(const char* msg, args&&... argv)
 {
 	std::ofstream logs;
 	logs.open("our_log.txt", std::ofstream::app | std::ofstream::out);
-	
 	logs << "[" << get_current_time() << "] " << msg;
 	(logs << ... << argv);
 	logs << '\n';

--- a/openGLdemo/Utilities.h
+++ b/openGLdemo/Utilities.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 #include <fstream>
+#include <chrono>
+#include <ctime>
 
 const char* extract_prog_name(const char* full)
 {

--- a/openGLdemo/rendering/GL/Version.h
+++ b/openGLdemo/rendering/GL/Version.h
@@ -1,23 +1,24 @@
 #pragma once
 #include <glad/glad.h>
 #include <stdio.h>
+#include "../../Utilities.h"
 
 void printGLinfo()
 {
 	const GLubyte* vendor = glGetString(GL_VENDOR);
-	printf("GL Vendor : %s\n", vendor);
+	write_log("GL Vendor : ", vendor);
 
 	const GLubyte* renderer = glGetString(GL_RENDERER);
-	printf("GL Renderer : %s\n", renderer);
+	write_log("GL Renderer : ", renderer);
 	
 	const GLubyte* version = glGetString(GL_VERSION);
-	printf("GL Version (string) : %s\n", version);
+	write_log("GL Version (string) : ", version);
 	
 	GLint major, minor;
 	glGetIntegerv(GL_MAJOR_VERSION, &major);
 	glGetIntegerv(GL_MINOR_VERSION, &minor);
-	printf("GL Version (integer) : %d.%d\n", major, minor);
+	write_log("GL Version (integer) : ", major, minor);
 	
 	const GLubyte* glslVersion = glGetString(GL_SHADING_LANGUAGE_VERSION);
-	printf("GLSL Version : %s\n", glslVersion);
+	write_log("GLSL Version : ", glslVersion);
 }


### PR DESCRIPTION
## Added
- Added logging to Version.h
- Added log timestamp
- Added var args to log function
## To note
I made some changes that need to be noted because they may not align with the standards of the repo
- Defined `#define _CRT_SECURE_NO_WARNINGS` for ctime (Source.cpp lines 1-3)
- In order to print the var args we use fold expressions(Utilities.h line 39). Fold expressions require using C++ 17 and up

## End result
Our log file now looks like this(I do not have 3D graphics drivers on this machine so it is example values): 
![image](https://user-images.githubusercontent.com/40400590/112217004-d8475280-8c2a-11eb-988c-a0ca1405e811.png)

